### PR TITLE
disable spellcheck and autocorrect for username

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,7 +9,8 @@
 <div class="register-form">
   <%= simple_form_for resource, as: resource_name, url: registration_path(resource_name), html: {role: 'form'} do |f| %>
       <h3><%= t('users.sign_up') %></h3>
-      <%= f.input :name, label: t('users.user_name'), hint: t('users.user_name_hint'), autofocus: true, required: false %>
+      <%= f.input :name, label: t('users.user_name'), hint: t('users.user_name_hint'), autofocus: true, required: false,
+        input_html: {autocapitalize: "off", autocorrect: "none", spellcheck: "false"} %>
       <%= f.input :nick, label: t('users.nick'), hint: t('users.nick_hint'), required: false %>
       <%= f.input :email, label: t('users.email'), hint: t('users.email_hint'), required: false %>
       <%= f.input :password, label: t('users.password'), hint: t('users.password_hint'), required: false %>


### PR DESCRIPTION
Since user name shouldn't contain uppercase letter, and it's not needed for OS and browser to perform spelling check, just disable it.